### PR TITLE
Use ORM to reset django_migrations table

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Changelog
 
+* *master* (unreleased)
+  * Use ORM to reset `django_migrations` table
+
 * *2.1.0* (2024-07-09)
   * Discover apps in nested directories
   * Use `BASE_DIR` instead of `MIGRATION_ZERO_APPS_DIR`

--- a/django_migration_zero/services/deployment.py
+++ b/django_migration_zero/services/deployment.py
@@ -1,7 +1,7 @@
 from logging import Logger
 
 from django.core.management import call_command
-from django.db import connections
+from django.db.migrations.recorder import MigrationRecorder
 
 from django_migration_zero.exceptions import InvalidMigrationTreeError
 from django_migration_zero.helpers.logger import get_logger
@@ -34,8 +34,7 @@ class DatabasePreparationService:
         # records of the other ones
         self.logger.info("Resetting migration history for all apps...")
 
-        with connections["default"].cursor() as cursor:
-            cursor.execute("DELETE FROM `django_migrations`")
+        MigrationRecorder.Migration.objects.all().delete()
 
         # Apply migrations via fake because the database is already up-to-date
         self.logger.info("Populating migration history.")


### PR DESCRIPTION
Hello!
I tried to move further using your package and I've noticed the following issue.

## Issue
I called the ` ./manage.py handle_migration_zero_reset` command and it failed with the following error:

```python
Traceback (most recent call last):
  File "/opt/venv/lib/python3.11/site-packages/django/db/backends/utils.py", line 103, in _execute
    return self.cursor.execute(sql)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.11/site-packages/psycopg/cursor.py", line 97, in execute
    raise ex.with_traceback(None)
psycopg.errors.SyntaxError: syntax error at or near "`"
LINE 1: DELETE FROM `django_migrations`
```

It looks like the issue with different SQL dialects. While backticks might be fine for SQLite or MySQL, they didn't work for PostgreSQL.

## Solution

The package could rely on the Django ORM instead of using raw SQL queries. This way DB calls can be independent from SQL dialects.