### PR TITLE
Acquire lock on singleton to handle parallel pod deployments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Changelog
 
+* *master* (unreleased)
+  * Lock rows to enable parallel deployments
+
 * *2.1.0* (2024-07-09)
   * Discover apps in nested directories
   * Use `BASE_DIR` instead of `MIGRATION_ZERO_APPS_DIR`

--- a/django_migration_zero/managers.py
+++ b/django_migration_zero/managers.py
@@ -5,11 +5,11 @@ from django_migration_zero.exceptions import MissingMigrationZeroConfigRecordErr
 from django_migration_zero.helpers.logger import get_logger
 
 
-class MigrationZeroConfigurationQuerySet(models.QuerySet):
+class MigrationZeroConfigurationManager(models.Manager):
     def fetch_singleton(self) -> None:
         logger = get_logger()
         try:
-            config_singleton = self.get()
+            config_singleton = self.select_for_update().get()
         except ProgrammingError:
             logger.warning(
                 "The migration zero table is missing. This might be ok for the first installation of "

--- a/django_migration_zero/managers.py
+++ b/django_migration_zero/managers.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
 from django.db import ProgrammingError, models
 
 from django_migration_zero.exceptions import MissingMigrationZeroConfigRecordError
@@ -5,31 +6,21 @@ from django_migration_zero.helpers.logger import get_logger
 
 
 class MigrationZeroConfigurationQuerySet(models.QuerySet):
-    pass
-
-
-class MigrationZeroConfigurationManager(models.Manager):
     def fetch_singleton(self) -> None:
         logger = get_logger()
         try:
-            number_records = self.count()
+            config_singleton = self.get()
         except ProgrammingError:
             logger.warning(
                 "The migration zero table is missing. This might be ok for the first installation of "
                 '"django-migration-zero" but if you see this warning after that point, something went sideways.'
             )
-            return None
-
-        if number_records > 1:
+            config_singleton = None
+        except MultipleObjectsReturned as e:
             raise MissingMigrationZeroConfigRecordError(
                 "Too many configuration records detected. There can only be one."
-            )
-
-        config_singleton = self.all().first()
-        if not config_singleton:
-            raise MissingMigrationZeroConfigRecordError("No configuration record found in the database.")
+            ) from e
+        except ObjectDoesNotExist as e:
+            raise MissingMigrationZeroConfigRecordError("No configuration record found in the database.") from e
 
         return config_singleton
-
-
-MigrationZeroConfigurationManager = MigrationZeroConfigurationManager.from_queryset(MigrationZeroConfigurationQuerySet)

--- a/django_migration_zero/models.py
+++ b/django_migration_zero/models.py
@@ -3,7 +3,7 @@ from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
 from django_migration_zero.helpers.logger import get_logger
-from django_migration_zero.managers import MigrationZeroConfigurationManager
+from django_migration_zero.managers import MigrationZeroConfigurationQuerySet
 
 
 class MigrationZeroConfiguration(models.Model):
@@ -14,7 +14,7 @@ class MigrationZeroConfiguration(models.Model):
     )
     migration_date = models.DateField(_("Migration date"), null=True, blank=True)
 
-    objects = MigrationZeroConfigurationManager()
+    objects = MigrationZeroConfigurationQuerySet.as_manager()
 
     class Meta:
         verbose_name = _("Configuration")

--- a/django_migration_zero/models.py
+++ b/django_migration_zero/models.py
@@ -3,7 +3,7 @@ from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
 from django_migration_zero.helpers.logger import get_logger
-from django_migration_zero.managers import MigrationZeroConfigurationQuerySet
+from django_migration_zero.managers import MigrationZeroConfigurationManager
 
 
 class MigrationZeroConfiguration(models.Model):
@@ -14,7 +14,7 @@ class MigrationZeroConfiguration(models.Model):
     )
     migration_date = models.DateField(_("Migration date"), null=True, blank=True)
 
-    objects = MigrationZeroConfigurationQuerySet.as_manager()
+    objects = MigrationZeroConfigurationManager()
 
     class Meta:
         verbose_name = _("Configuration")

--- a/django_migration_zero/services/deployment.py
+++ b/django_migration_zero/services/deployment.py
@@ -1,7 +1,7 @@
 from logging import Logger
 
 from django.core.management import call_command
-from django.db import connections, transaction
+from django.db import transaction
 from django.db.migrations.recorder import MigrationRecorder
 
 from django_migration_zero.exceptions import InvalidMigrationTreeError
@@ -26,7 +26,7 @@ class DatabasePreparationService:
         self.logger.info("Starting migration zero database adjustments...")
 
         # Fetch configuration singleton from database
-        config_singleton = MigrationZeroConfiguration.objects.select_for_update().fetch_singleton()
+        config_singleton = MigrationZeroConfiguration.objects.fetch_singleton()
 
         # If we encountered a problem or are not planning to do a migration reset, we are done here
         if not (config_singleton and config_singleton.is_migration_applicable):

--- a/django_migration_zero/services/deployment.py
+++ b/django_migration_zero/services/deployment.py
@@ -1,7 +1,7 @@
 from logging import Logger
 
 from django.core.management import call_command
-from django.db import connections
+from django.db import connections, transaction
 
 from django_migration_zero.exceptions import InvalidMigrationTreeError
 from django_migration_zero.helpers.logger import get_logger
@@ -20,11 +20,12 @@ class DatabasePreparationService:
 
         self.logger = get_logger()
 
+    @transaction.atomic
     def process(self):
         self.logger.info("Starting migration zero database adjustments...")
 
         # Fetch configuration singleton from database
-        config_singleton = MigrationZeroConfiguration.objects.fetch_singleton()
+        config_singleton = MigrationZeroConfiguration.objects.select_for_update().fetch_singleton()
 
         # If we encountered a problem or are not planning to do a migration reset, we are done here
         if not (config_singleton and config_singleton.is_migration_applicable):

--- a/tests/services/test_deployment.py
+++ b/tests/services/test_deployment.py
@@ -1,12 +1,14 @@
 from logging import Logger
+from threading import Thread
 from unittest import mock
+from unittest.mock import Mock, call
 
-from django.test import TestCase
+from django.test import TestCase, TransactionTestCase
 from django.utils import timezone
 from freezegun import freeze_time
 
 from django_migration_zero.exceptions import InvalidMigrationTreeError
-from django_migration_zero.managers import MigrationZeroConfigurationManager
+from django_migration_zero.managers import MigrationZeroConfigurationQuerySet
 from django_migration_zero.models import MigrationZeroConfiguration
 from django_migration_zero.services.deployment import DatabasePreparationService
 
@@ -38,7 +40,7 @@ class DatabasePreparationServiceTest(TestCase):
         self.assertFalse(self.config.migration_imminent)
 
     @mock.patch.object(MigrationZeroConfiguration, "is_migration_applicable", return_value=False)
-    @mock.patch.object(MigrationZeroConfigurationManager, "fetch_singleton", return_value=None)
+    @mock.patch.object(MigrationZeroConfigurationQuerySet, "fetch_singleton", return_value=None)
     def test_process_case_is_migration_applicable_false(self, *args):
         # Setup
         self.config.delete()
@@ -81,3 +83,56 @@ class DatabasePreparationServiceTest(TestCase):
 
         self.assertEqual(calls[1].args, ("migrate",))
         self.assertEqual(calls[1].kwargs, {"check": True})
+
+
+class DatabasePreparationServiceTestParallelDeployment(TransactionTestCase):
+    @mock.patch("django_migration_zero.services.deployment.get_logger")
+    def test_process_multiple_threads(self, mock_get_logger):
+        """Test parallel deployments to multiple pods."""
+        # Setup
+        mock_logger_info = Mock(return_value=None)
+        mock_get_logger.return_value = Mock(info=mock_logger_info)
+        config, _ = MigrationZeroConfiguration.objects.update_or_create(
+            defaults={
+                "migration_imminent": True,
+                "migration_date": timezone.now().date(),
+            }
+        )
+
+        # Testable
+        number_of_pods = 1
+        threads = [Thread(target=DatabasePreparationService().process) for _ in range(number_of_pods)]
+
+        for thread in threads:
+            thread.start()
+
+        for thread in threads:
+            thread.join()
+
+        # Assertions
+        self.assertEqual(mock_logger_info.call_count, 6 + number_of_pods, msg=mock_logger_info.call_args_list)
+        mock_logger_info.assert_has_calls(
+            [
+                call("Starting migration zero database adjustments..."),
+                call("Resetting migration history for all apps..."),
+                call("Populating migration history."),
+                call("Checking migration integrity."),
+                call("All good."),
+                call("Deactivating migration zero switch in database."),
+                call("Process successfully finished."),
+            ],
+            any_order=True,
+        )
+        self.assertEqual(
+            len(
+                [
+                    mock_call
+                    for mock_call in mock_logger_info.call_args_list
+                    if mock_call == call("Starting migration zero database adjustments...")
+                ]
+            ),
+            number_of_pods,
+        )
+
+        config.refresh_from_db()
+        self.assertFalse(config.migration_imminent)

--- a/tests/services/test_deployment.py
+++ b/tests/services/test_deployment.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 from freezegun import freeze_time
 
 from django_migration_zero.exceptions import InvalidMigrationTreeError
-from django_migration_zero.managers import MigrationZeroConfigurationQuerySet
+from django_migration_zero.managers import MigrationZeroConfigurationManager
 from django_migration_zero.models import MigrationZeroConfiguration
 from django_migration_zero.services.deployment import DatabasePreparationService
 
@@ -40,7 +40,7 @@ class DatabasePreparationServiceTest(TestCase):
         self.assertFalse(self.config.migration_imminent)
 
     @mock.patch.object(MigrationZeroConfiguration, "is_migration_applicable", return_value=False)
-    @mock.patch.object(MigrationZeroConfigurationQuerySet, "fetch_singleton", return_value=None)
+    @mock.patch.object(MigrationZeroConfigurationManager, "fetch_singleton", return_value=None)
     def test_process_case_is_migration_applicable_false(self, *args):
         # Setup
         self.config.delete()

--- a/tests/test_managers.py
+++ b/tests/test_managers.py
@@ -5,6 +5,7 @@ from django.db import ProgrammingError
 from django.test import TestCase
 
 from django_migration_zero.exceptions import MissingMigrationZeroConfigRecordError
+from django_migration_zero.managers import MigrationZeroConfigurationQuerySet
 from django_migration_zero.models import MigrationZeroConfiguration
 
 
@@ -18,7 +19,7 @@ class MigrationZeroConfigurationManagerTest(TestCase):
     def test_fetch_singleton_singleton_exists_via_migration(self):
         self.assertEqual(MigrationZeroConfiguration.objects.all().count(), 1)
 
-    @mock.patch.object(MigrationZeroConfiguration.objects, "count", side_effect=ProgrammingError)
+    @mock.patch.object(MigrationZeroConfigurationQuerySet, "get", side_effect=ProgrammingError)
     def test_fetch_singleton_database_error(self, *args):
         self.assertIsNone(MigrationZeroConfiguration.objects.fetch_singleton())
 

--- a/tests/test_managers.py
+++ b/tests/test_managers.py
@@ -5,7 +5,7 @@ from django.db import ProgrammingError
 from django.test import TestCase
 
 from django_migration_zero.exceptions import MissingMigrationZeroConfigRecordError
-from django_migration_zero.managers import MigrationZeroConfigurationQuerySet
+from django_migration_zero.managers import MigrationZeroConfigurationManager
 from django_migration_zero.models import MigrationZeroConfiguration
 
 
@@ -19,7 +19,7 @@ class MigrationZeroConfigurationManagerTest(TestCase):
     def test_fetch_singleton_singleton_exists_via_migration(self):
         self.assertEqual(MigrationZeroConfiguration.objects.all().count(), 1)
 
-    @mock.patch.object(MigrationZeroConfigurationQuerySet, "get", side_effect=ProgrammingError)
+    @mock.patch.object(MigrationZeroConfigurationManager, "select_for_update", side_effect=ProgrammingError)
     def test_fetch_singleton_database_error(self, *args):
         self.assertIsNone(MigrationZeroConfiguration.objects.fetch_singleton())
 


### PR DESCRIPTION
Hello (again)! 😄
I tried to move further using your package and I've noticed the following issue along with my team.

## Issue

When deploying to multiple pods, we may encounter a situation when more than one pod runs the `handle_migration_zero_reset` command at the same time. It may cause issues on deployment.

## Solution

The `select_for_update` QuerySet method could be used to create a lock on a row with singleton and ensure a single access at a time.

It required changing a Manager class to a QuerySet class for chaining QS methods. I also modified the `fetch_singleton` method to use a single query on the locked row instead of two queries.

### Note

The test DB in the project runs on the SQLite that doesn't work with `select_for_update`. That's why I set the `number_of_pods = 1` in the test. When set to 3, it fails. But I've also tested the package on the PostgreSQL project and the test passed with `number_of_pods = 3` thanks to the `select_for_update`. Changing a DB engine to the one supporting `SELECT ... FOR UPDATE` could help here.